### PR TITLE
Get keyword ignore case sensitivity

### DIFF
--- a/source/DD4T.Providers.SDLWeb8/TridionTaxonomyProvider.cs
+++ b/source/DD4T.Providers.SDLWeb8/TridionTaxonomyProvider.cs
@@ -54,7 +54,7 @@ namespace DD4T.Providers.SDLWeb8
             foreach (var currentKeyword in taxonomy)
             {
                 string currentKeywordName = currentKeyword.KeywordName;
-                if (currentKeywordName != keywordName)
+                if (!currentKeywordName.Equals(keywordName, StringComparison.InvariantCultureIgnoreCase))
                 {
                     foundKeyword = recursive(currentKeyword.KeywordChildren.Cast<Keyword>().ToList(), keywordName);
                 }
@@ -119,7 +119,7 @@ namespace DD4T.Providers.SDLWeb8
             foreach (var item in keywords)
             {
 
-                if (item.KeywordName == valueToLookFor)
+                if (item.KeywordName.Equals(valueToLookFor, StringComparison.InvariantCultureIgnoreCase))
                 {
                     returnValue = item;
                 }


### PR DESCRIPTION
Customer gets metadata lowercased. This solution doesn't affect current
implementations and is a better way of doing comparissons anyway.